### PR TITLE
Fix for memo display

### DIFF
--- a/src/utils/standardization/standardizeTxObj.js
+++ b/src/utils/standardization/standardizeTxObj.js
@@ -9,7 +9,16 @@ import { ETH } from "../constants/intervalConstants";
 // Makes transaction objects from lightwalletd client resemble those from electrum,
 // for predictable, standard behaviour
 export const standardizeDlightTxObj = (txObj) => {
-  const { address, amount, category, height, status, time, txid, memo } = txObj
+  const { address, amount, category, height, status, time, txid, memos } = txObj
+
+  // check with michael to ensure we don't already have a function like this
+  // calling decodeMemo was causing every incoming tx to display an envelope
+  // decodeMemo in memoUtils also decodes base64 - SDKs don't require this
+  const normalizedMemo =
+    Array.isArray(memos)
+      ? memos.find(m => typeof m === "string" && m.trim().length > 0) ?? null
+      : null;
+
   return {
     address,
     amount: typeof amount !== "string" ? satsToCoins(BigNumber(amount.toString())) : satsToCoins(BigNumber(amount)),
@@ -19,7 +28,7 @@ export const standardizeDlightTxObj = (txObj) => {
     status,
     timestamp: time,
     txid,
-    memo: decodeMemo(memo),
+    memo: normalizedMemo,
   };
 }
 

--- a/src/utils/standardization/standardizeTxObj.js
+++ b/src/utils/standardization/standardizeTxObj.js
@@ -11,9 +11,7 @@ import { ETH } from "../constants/intervalConstants";
 export const standardizeDlightTxObj = (txObj) => {
   const { address, amount, category, height, status, time, txid, memos } = txObj
 
-  // check with michael to ensure we don't already have a function like this
-  // calling decodeMemo was causing every incoming tx to display an envelope
-  // decodeMemo in memoUtils also decodes base64 - SDKs don't require this
+  // normalize memo, remove duplicates if they exist
   const normalizedMemo =
     Array.isArray(memos)
       ? memos.find(m => typeof m === "string" && m.trim().length > 0) ?? null


### PR DESCRIPTION
This PR will include fixes for:

1.) Incoming memo display
~~2.) Fixing (now confusing) pending amount delta for balance~~

~~Regarding no. 2: We need to support some different logic since Zcash's changes to how `confirmed` vs `available` are calculated. `total.minus(available)` only shows pending incoming (not outgoing) i.e. "inbound amounts not yet available to spend" (which includes change).~~

~~Item No. 2 is not yet included, so please wait to merge.~~

Item number 2 was not present in legacy app either.  While i think this could be improved later, we'll hold off for now.  This is good for merge.